### PR TITLE
Share date range knowledge between calendars

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,14 @@ Update the minimum/earliest date that can be selected.
 
 Update the maximum/latest date that can be selected.
 
+`picker.setStartRange()`
+
+Update the start range date if you are using multiple calendars with a range.
+
+`picker.setEndRange()`
+
+Update the end range date if you are using multiple calendars with a range.
+
 ### Show and hide datepicker
 
 `picker.isVisible()`

--- a/css/pikaday.css
+++ b/css/pikaday.css
@@ -181,6 +181,10 @@ http://nicolasgallagher.com/micro-clearfix-hack/
     border-radius: 3px;
 }
 
+.is-inrange .pika-button {
+    background: #D5E9F7;
+}
+
 .is-disabled .pika-button {
     pointer-events: none;
     cursor: default;

--- a/css/pikaday.css
+++ b/css/pikaday.css
@@ -185,6 +185,20 @@ http://nicolasgallagher.com/micro-clearfix-hack/
     background: #D5E9F7;
 }
 
+.is-startrange .pika-button {
+    box-shadow: none;
+    color: #fff;
+    border-radius: 3px;
+    background: #6CB31D;
+}
+
+.is-endrange .pika-button {
+    box-shadow: none;
+    color: #fff;
+    border-radius: 3px;
+    background: #33aaff;
+}
+
 .is-disabled .pika-button {
     pointer-events: none;
     cursor: default;
@@ -193,10 +207,10 @@ http://nicolasgallagher.com/micro-clearfix-hack/
 }
 
 .pika-button:hover {
-    color: #fff !important;
-    background: #ff8000 !important;
-    box-shadow: none !important;
-    border-radius: 3px !important;
+    color: #fff;
+    background: #ff8000;
+    box-shadow: none;
+    border-radius: 3px;
 }
 
 /* styling for abbr */
@@ -204,4 +218,3 @@ http://nicolasgallagher.com/micro-clearfix-hack/
     border-bottom: none;
     cursor: help;
 }
-

--- a/examples/date-range.html
+++ b/examples/date-range.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+    <title>Pikaday - Date Range example</title>
+    <meta name="author" content="David Bushell">
+    <link rel="stylesheet" href="../css/pikaday.css">
+    <link rel="stylesheet" href="../css/site.css">
+</head>
+<body>
+    <h1>Pikaday - Date Range example</h1>
+
+    <p class="large">A refreshing JavaScript Datepicker — lightweight, no dependencies, modular CSS.</p>
+
+    <p><a href="https://github.com/dbushell/Pikaday"><strong>Pikaday source on GitHub</strong></a></p>
+
+    <div style="display: inline-block">
+        <label for="start">Start:</label>
+        <br>
+        <input type="text" id="start">
+    </div>
+
+    <div style="display: inline-block">
+        <label for="end">End:</label>
+        <br>
+        <input type="text" id="end">
+    </div>
+
+    <h2>What is this?</h2>
+
+    <p>Since version 1.0 Pikaday is a stable and battle tested date-picker. Feel free to use it however you like but please report any bugs or feature requests to the <a href="https://github.com/dbushell/Pikaday/issues">GitHub issue tracker</a>, thanks!</p>
+
+    <p class="small">Copyright &copy; 2014 <a href="http://dbushell.com/">David Bushell</a> | BSD &amp; MIT license</p>
+
+
+    <script src="../pikaday.js"></script>
+    <script>
+    var startDate,
+        endDate,
+        startPicker = new Pikaday({
+            field: document.getElementById('start'),
+            minDate: new Date(),
+            maxDate: new Date(2020, 12, 31),
+            onSelect: function() {
+                startDate = this.getDate();
+                this.setStartRange(startDate);
+                endPicker.setMinDate(startDate);
+                endPicker.setStartRange(startDate);
+            }
+        }),
+        endPicker = new Pikaday({
+            field: document.getElementById('end'),
+            minDate: new Date(),
+            maxDate: new Date(2020, 12, 31),
+            onSelect: function() {
+                endDate = this.getDate();
+                this.setEndRange(endDate);
+                startPicker.setEndRange(endDate);
+            }
+        });
+    </script>
+</body>
+</html>

--- a/pikaday.js
+++ b/pikaday.js
@@ -219,6 +219,9 @@
         minMonth: undefined,
         maxMonth: undefined,
 
+        startRange: null,
+        endRange: null,
+
         isRTL: false,
 
         // Additional text to append to the year in the calendar title
@@ -269,7 +272,7 @@
         return abbr ? opts.i18n.weekdaysShort[day] : opts.i18n.weekdays[day];
     },
 
-    renderDay = function(d, m, y, isSelected, isToday, isDisabled, isEmpty)
+    renderDay = function(d, m, y, isSelected, isToday, isDisabled, isEmpty, isInRange)
     {
         if (isEmpty) {
             return '<td class="is-empty"></td>';
@@ -283,6 +286,9 @@
         }
         if (isSelected) {
             arr.push('is-selected');
+        }
+        if (isInRange) {
+            arr.push('is-inrange');
         }
         return '<td data-day="' + d + '" class="' + arr.join(' ') + '">' +
                  '<button class="pika-button pika-day" type="button" ' +
@@ -825,6 +831,16 @@
             this._o.maxDate = value;
         },
 
+        setStartRange: function(value)
+        {
+            this._o.startRange = value;
+        },
+
+        setEndRange: function(value)
+        {
+            this._o.endRange = value;
+        },
+
         /**
          * refresh the HTML
          */
@@ -956,12 +972,16 @@
                     isSelected = isDate(this._d) ? compareDates(day, this._d) : false,
                     isToday = compareDates(day, now),
                     isEmpty = i < before || i >= (days + before),
+                    isInRange = opts.startRange && opts.endRange && opts.startRange < day && day < opts.endRange,
                     isDisabled = (opts.minDate && day < opts.minDate) ||
                                  (opts.maxDate && day > opts.maxDate) ||
                                  (opts.disableWeekends && isWeekend(day)) ||
                                  (opts.disableDayFn && opts.disableDayFn(day));
 
-                row.push(renderDay(1 + (i - before), month, year, isSelected, isToday, isDisabled, isEmpty));
+                if (opts.startRange) isSelected = isSelected || compareDates(opts.startRange, day);
+                if (opts.endRange) isSelected = isSelected || compareDates(opts.endRange, day);
+
+                row.push(renderDay(1 + (i - before), month, year, isSelected, isToday, isDisabled, isEmpty, isInRange));
 
                 if (++r === 7) {
                     if (opts.showWeekNumber) {

--- a/pikaday.js
+++ b/pikaday.js
@@ -990,13 +990,13 @@
                     day: 1 + (i - before),
                     month: month,
                     year: year,
-                    isSelected: isSelected,
-                    isToday: isToday,
                     isDisabled: isDisabled,
                     isEmpty: isEmpty,
-                    isStartRange: isStartRange,
                     isEndRange: isEndRange,
-                    isInRange: isInRange
+                    isInRange: isInRange,
+                    isSelected: isSelected,
+                    isStartRange: isStartRange,
+                    isToday: isToday
                 };
 
                 row.push(renderDay(dayConfig));

--- a/pikaday.js
+++ b/pikaday.js
@@ -272,28 +272,34 @@
         return abbr ? opts.i18n.weekdaysShort[day] : opts.i18n.weekdays[day];
     },
 
-    renderDay = function(d, m, y, isSelected, isToday, isDisabled, isEmpty, isInRange)
+    renderDay = function(opts)
     {
-        if (isEmpty) {
+        if (opts.isEmpty) {
             return '<td class="is-empty"></td>';
         }
         var arr = [];
-        if (isDisabled) {
+        if (opts.isDisabled) {
             arr.push('is-disabled');
         }
-        if (isToday) {
+        if (opts.isToday) {
             arr.push('is-today');
         }
-        if (isSelected) {
+        if (opts.isSelected) {
             arr.push('is-selected');
         }
-        if (isInRange) {
+        if (opts.isInRange) {
             arr.push('is-inrange');
         }
-        return '<td data-day="' + d + '" class="' + arr.join(' ') + '">' +
+        if (opts.isStartRange) {
+            arr.push('is-startrange');
+        }
+        if (opts.isEndRange) {
+            arr.push('is-endrange');
+        }
+        return '<td data-day="' + opts.day + '" class="' + arr.join(' ') + '">' +
                  '<button class="pika-button pika-day" type="button" ' +
-                    'data-pika-year="' + y + '" data-pika-month="' + m + '" data-pika-day="' + d + '">' +
-                        d +
+                    'data-pika-year="' + opts.year + '" data-pika-month="' + opts.month + '" data-pika-day="' + opts.day + '">' +
+                        opts.day +
                  '</button>' +
                '</td>';
     },
@@ -968,20 +974,32 @@
             cells += 7 - after;
             for (var i = 0, r = 0; i < cells; i++)
             {
-                var day = new Date(year, month, 1 + (i - before)),
+                var dayConfig,
+                    day = new Date(year, month, 1 + (i - before)),
                     isSelected = isDate(this._d) ? compareDates(day, this._d) : false,
                     isToday = compareDates(day, now),
                     isEmpty = i < before || i >= (days + before),
+                    isStartRange = opts.startRange && compareDates(opts.startRange, day),
+                    isEndRange = opts.endRange && compareDates(opts.endRange, day),
                     isInRange = opts.startRange && opts.endRange && opts.startRange < day && day < opts.endRange,
                     isDisabled = (opts.minDate && day < opts.minDate) ||
                                  (opts.maxDate && day > opts.maxDate) ||
                                  (opts.disableWeekends && isWeekend(day)) ||
-                                 (opts.disableDayFn && opts.disableDayFn(day));
+                                 (opts.disableDayFn && opts.disableDayFn(day)),
+                dayConfig = {
+                    day: 1 + (i - before),
+                    month: month,
+                    year: year,
+                    isSelected: isSelected,
+                    isToday: isToday,
+                    isDisabled: isDisabled,
+                    isEmpty: isEmpty,
+                    isStartRange: isStartRange,
+                    isEndRange: isEndRange,
+                    isInRange: isInRange
+                };
 
-                if (opts.startRange) isSelected = isSelected || compareDates(opts.startRange, day);
-                if (opts.endRange) isSelected = isSelected || compareDates(opts.endRange, day);
-
-                row.push(renderDay(1 + (i - before), month, year, isSelected, isToday, isDisabled, isEmpty, isInRange));
+                row.push(renderDay(dayConfig));
 
                 if (++r === 7) {
                     if (opts.showWeekNumber) {

--- a/pikaday.js
+++ b/pikaday.js
@@ -900,11 +900,11 @@
         adjustPosition: function()
         {
             var field, pEl, width, height, viewportWidth, viewportHeight, scrollTop, left, top, clientRect;
-            
+
             if (this._o.container) return;
-            
+
             this.el.style.position = 'absolute';
-            
+
             field = this._o.trigger;
             pEl = field;
             width = this.el.offsetWidth;


### PR DESCRIPTION
Pikaday works well for date range selection by creating two Pikaday objects and adjusting the Min/Max dates based on whats been chosen on each e.g.:

``` javascript
var startPicker = new Pikaday({
    field: document.getElementById('start'),
    onSelect: function() {
        endPicker.setMinDate(this.getDate());
    }
});
var endPicker = new Pikaday({
    field: document.getElementById('end'),
    onSelect: function() {
        startPicker.setMaxDate(this.getDate());
    }
});
```

This works by limiting the min date on the `endPicker` based on what is selected on the `startPicker` and vice versa. 

The "End" date picker however doesn't know the selected start date, or the dates within the selected range, which is useful for a UI such as:
![calendar](https://cloud.githubusercontent.com/assets/1018141/8047853/6052fab4-0e9e-11e5-96b0-3eb38d8bb633.png)

Nathan Cahill has done most of the work getting this working here: https://github.com/dbushell/Pikaday/issues/332

I have added additional classes to the datepicker to allow styling of the start and end range.

The updated usage would now be:

``` javascript
var startPicker = new Pikaday({
    field: document.getElementById('start'),
    onSelect: function() {
        startDate = this.getDate();
        this.setStartRange(startDate);
        endPicker.setMinDate(startDate);
        endPicker.setStartRange(startDate);
    }
});
var endPicker = new Pikaday({
    field: document.getElementById('end'),
    onSelect: function() {
        endDate = this.getDate();
        this.setEndRange(endDate);
        startPicker.setMaxDate(endDate);
        startPicker.setEndRange(endDate);
    }
});
```
